### PR TITLE
Use module level logger

### DIFF
--- a/zeyrek/rulebasedanalyzer.py
+++ b/zeyrek/rulebasedanalyzer.py
@@ -4,7 +4,7 @@ from zeyrek.attributes import PhoneticAttribute, calculate_phonetic_attributes, 
 from zeyrek.morphotactics import SurfaceTransition, SearchPath, generate_surface, nom, pnon
 import logging
 
-logging.basicConfig(level=logging.ERROR)
+logger = logging.getLogger(__name__)
 
 
 class RuleBasedAnalyzer:
@@ -54,15 +54,15 @@ class RuleBasedAnalyzer:
                     and PhoneticAttribute.CannotTerminate
                     not in path.phonetic_attributes
                 ):
-                    logging.warning(f"APPENDING RESULT: {path}")
+                    logger.warning(f"APPENDING RESULT: {path}")
                     result.append(path)
                     continue
                 # Creates new paths with outgoing and matching transitions.
                 new_paths = self.advance(path)
-                logging.debug(f"\n--\nNew paths are: ")
+                logger.debug(f"\n--\nNew paths are: ")
                 for p in new_paths:
-                    logging.debug(f"-- {p}")
-                logging.debug('')
+                    logger.debug(f"-- {p}")
+                logger.debug('')
                 all_new_paths.extend(new_paths)
             current_paths = all_new_paths
         return result
@@ -81,7 +81,7 @@ class RuleBasedAnalyzer:
         for transition in path.current_state.outgoing:
             # if tail is empty and this transitions surface is not empty, no need to check.
             if len(path.tail) == 0 and transition.has_surface_form:
-                logging.debug(f"Rejecting path {path}: Path and transition surface mismatch: ")
+                logger.debug(f"Rejecting path {path}: Path and transition surface mismatch: ")
                 continue
 
             surface = generate_surface(
@@ -91,12 +91,12 @@ class RuleBasedAnalyzer:
             # no need to go further if generated surface form is not a prefix of the paths's tail.
             tail_starts_with = path.tail.startswith(surface)
             if not tail_starts_with:
-                logging.debug(f"Rejecting path {path}: tail doesnt start with {path.tail}-{surface}")
+                logger.debug(f"Rejecting path {path}: tail doesnt start with {path.tail}-{surface}")
                 continue
 
             # check conditions.
             if not transition.can_pass(path):
-                logging.debug(f"Rejecting path {path}-{transition}: can't pass")
+                logger.debug(f"Rejecting path {path}-{transition}: can't pass")
                 continue
 
             # epsilon (empty) transition. Add and continue. Use existing attributes.
@@ -104,7 +104,7 @@ class RuleBasedAnalyzer:
                 blank_surface_transition = SurfaceTransition("", transition)
                 new_path = path.copy(blank_surface_transition, path.phonetic_attributes)
                 new_paths.append(new_path)
-                logging.debug(f"Appending path {new_path}")
+                logger.debug(f"Appending path {new_path}")
                 continue
 
             surface_transition = SurfaceTransition(surface, transition)
@@ -127,11 +127,11 @@ class RuleBasedAnalyzer:
                 attributes.add(PhoneticAttribute.ExpectsVowel)
                 attributes.add(PhoneticAttribute.CannotTerminate)
             p = path.copy(surface_transition, attributes)
-            logging.debug(f"P path: {p}")
+            logger.debug(f"P path: {p}")
             new_paths.append(p)
-        logging.debug(f"FINAL: ")
+        logger.debug(f"FINAL: ")
         for i, p in enumerate(new_paths):
-            logging.debug(f"\t {i}: {p}")
+            logger.debug(f"\t {i}: {p}")
         # print()
         return new_paths
 


### PR DESCRIPTION
Instead of using the root level logger, a module level logger is
used. This prevents zeyrek's logger from interfering with other
programs that might be using the root level logger. Additionally,
being a named logger, zeyrek's new logger can be configured
separately if needed.

The rule to set logging level to ERROR has also been removed as
it can be set externally through the new module level logger.

Signed-off-by: Abhishek Kumar <abhi.kr.2100@gmail.com>