### PR TITLE
Change lemmatizer API to return a list of lemmas by default

### DIFF
--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -99,6 +99,13 @@ def test_sentence():
     assert 'bu' in result[0][1]
 
 
+def test_compound_words():
+    lemmer = MorphAnalyzer()
+    compound_word = "Zeytinyağlı"
+    result = lemmer.lemmatize(compound_word)
+    assert 'zeytinyağı' in result
+
+
 def test_single_lemma():
     analyzer = MorphAnalyzer()
     res = analyzer.lemmatize("Şu dünyadaki sevilen kişi sevmeyi bilendir.")

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -97,3 +97,9 @@ def test_sentence():
     result = lemmer.lemmatize(sentence)
     assert 'Bunu' in result[0][0]
     assert 'bu' in result[0][1]
+
+
+def test_last_lemma():
+    analyzer = MorphAnalyzer()
+    res = analyzer.lemmatize("Şu dünyadaki sevilen kişi sevmeyi bilendir.")
+    assert res == ['şu', 'Dünya', 'sevmek', 'kişi', 'sevmek', 'Bilen', '.']

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -75,7 +75,7 @@ def lex_from_lines():
 
 
 def test_analysis(lex_from_lines):
-    lemmer = MorphAnalyzer(lexicon=lex_from_lines)
+    lemmer = MorphAnalyzer(lexicon=lex_from_lines, return_all_lemmas=True)
     analysis = lemmer.analyze('elma')
     assert analysis is not None
     analysis = lemmer.analyze('beyazlaştırıcı')
@@ -92,14 +92,14 @@ def test_default_lexicon():
 
 
 def test_sentence():
-    lemmer = MorphAnalyzer()
+    lemmer = MorphAnalyzer(return_all_lemmas=True)
     sentence = "Bunu okuyabiliyorum"
     result = lemmer.lemmatize(sentence)
     assert 'Bunu' in result[0][0]
     assert 'bu' in result[0][1]
 
 
-def test_last_lemma():
+def test_single_lemma():
     analyzer = MorphAnalyzer()
     res = analyzer.lemmatize("Şu dünyadaki sevilen kişi sevmeyi bilendir.")
-    assert res == ['şu', 'Dünya', 'sevmek', 'kişi', 'sevmek', 'Bilen', '.']
+    assert res == ['şu', 'dünya', 'sevmek', 'kişi', 'sevmek', 'bilmek', '.']


### PR DESCRIPTION
This PR changes the lemmatizer behavior in a breaking way: now, by default, it returns a list of lemmas for the text, instead of a list of tuples with the word and a list of all possible lemmas. To get the old behavior, pass `return_all_lemmas=True` to the `MorphAnalyzer` class.

Also, the proper noun lemmas are now filtered based on whether the first letter of the word is capital or not. So, when lemmatizing "bilen", it returns "bilmek" instead of the proper noun "Bilen".